### PR TITLE
Fixed incorrect signed integer usage in interop call leading to being unable to provide negative directional or rotational inputs.

### DIFF
--- a/src/Native/HID/HidInterop.cs
+++ b/src/Native/HID/HidInterop.cs
@@ -16,10 +16,10 @@ namespace RoboPhredDev.Shipbreaker.SixAxis.Native.HID
         private static extern NtStatus HidP_GetButtonCaps(HidPReportType reportType, [Out] HidPButtonCaps[] buttonCaps, ref ushort buttonCapsLength, IntPtr preparsedData);
 
         [DllImport("hid")]
-        private static extern NtStatus HidP_GetUsageValue(HidPReportType reportType, ushort usagePage, ushort linkCollection, ushort usage, out int usageValue, IntPtr preparsedData, byte[] report, uint reportLength);
+        private static extern NtStatus HidP_GetUsageValue(HidPReportType reportType, ushort usagePage, ushort linkCollection, ushort usage, out uint usageValue, IntPtr preparsedData, byte[] report, uint reportLength);
 
         [DllImport("hid")]
-        private static extern NtStatus HidP_GetScaledUsageValue(HidPReportType reportType, ushort usagePage, ushort linkCollection, ushort usage, out int usageValue, IntPtr preparsedData, byte[] report, uint reportLength);
+        private static extern NtStatus HidP_GetScaledUsageValue(HidPReportType reportType, ushort usagePage, ushort linkCollection, ushort usage, out uint usageValue, IntPtr preparsedData, byte[] report, uint reportLength);
 
         [DllImport("hid")]
         private static extern NtStatus HidP_GetUsages(HidPReportType reportType, ushort usagePage, ushort linkCollection, [Out] ushort[] usageList, ref uint usageLength, IntPtr preparsedData, byte[] report, uint reportLength);
@@ -106,7 +106,7 @@ namespace RoboPhredDev.Shipbreaker.SixAxis.Native.HID
 
         public static int? GetUsageValue(HidPReportType reportType, ushort usagePage, ushort linkCollection, ushort usage, IntPtr preparsedData, byte[] report, uint reportLength)
         {
-            var result = HidP_GetUsageValue(reportType, usagePage, linkCollection, usage, out int value, preparsedData, report, reportLength);
+            var result = HidP_GetUsageValue(reportType, usagePage, linkCollection, usage, out uint value, preparsedData, report, reportLength);
             // FIXME: Allowing incompatible report ids through for now, until we figure out how to detect what the id of a report is.
             if (result == NtStatus.Null || result == NtStatus.IncompatibleReportId)
             {
@@ -117,12 +117,15 @@ namespace RoboPhredDev.Shipbreaker.SixAxis.Native.HID
                 throw new InvalidOperationException($"{result} while getting usage value for {usagePage} {linkCollection} {usage}");
             }
 
-            return value;
+            unchecked
+            {
+                return (short)(ushort)value;
+            }
         }
 
         public static int? GetScaledUsageValue(HidPReportType reportType, ushort usagePage, ushort linkCollection, ushort usage, IntPtr preparsedData, byte[] report, uint reportLength)
         {
-            var result = HidP_GetScaledUsageValue(reportType, usagePage, linkCollection, usage, out int value, preparsedData, report, reportLength);
+            var result = HidP_GetScaledUsageValue(reportType, usagePage, linkCollection, usage, out uint value, preparsedData, report, reportLength);
             // FIXME: Allowing incompatible report ids through for now, until we figure out how to detect what the id of a report is.
             if (result == NtStatus.Null || result == NtStatus.IncompatibleReportId)
             {
@@ -133,7 +136,10 @@ namespace RoboPhredDev.Shipbreaker.SixAxis.Native.HID
                 throw new InvalidOperationException($"{result} while getting scaled usage value for {usagePage} {linkCollection} {usage}");
             }
 
-            return value;
+            unchecked
+            {
+                return (short)(ushort)value;
+            }
         }
 
         public static ushort[] GetUsages(HidPReportType reportType, ushort usagePage, ushort linkCollection, IntPtr preparsedData, byte[] report, uint reportLength)


### PR DESCRIPTION
3DConnection SpaceMouse Wireless
SixAxis `2.0.0`
Hardspace: Shipbreaker `1.3.0`
3DxWare `10.8.12.3545`
3DxWinCore `17.8.12.19992`

Input in the negative ranges will always immediately clamp to `1.0` on that axis. This makes moving or turning in the negative direction (of user input, not world coordinates) impossible.

Inspecting `RoboPhredDev.Shipbreaker.SixAxis.InputManager` during runtime using https://github.com/ManlyMarco/RuntimeUnityEditor confirms that moving the spacemouse away from the origin in the negative direction in both translation and rotation will immediately snap that axis to a value of `1.0`. 

After some debugging, it appears as though the `HidP_GetUsageValue` interop call done in `HidInterop` uses an `int` for the `usageValue` out parameter, when https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/hidpi/nf-hidpi-hidp_getusagevalue indicates the value should be an unsigned (32 bit) integer (so a `uint`). This leads to these calls resulting in an effective input range of 0-350 for the positive direction, and 65536-65186 for the negative direction. Clear sign that we're dealing with a sign issue ;)

I don't know if this affects just the SpaceMouse wireless, or that this applies to all devices. I also don't know if the assumption of the underlying type being a short applies to all (potentially) supported devices. I've not put in the effort to make this configurable.